### PR TITLE
Test IDM-to-IDM trust with ipalab-config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Result directories for ipalab-config
+/**/logs_*/
+/**/idm2idm-trust/

--- a/ipalab-config/README.md
+++ b/ipalab-config/README.md
@@ -1,0 +1,39 @@
+# Running IPA-to-IPA trust with ipalab-config
+
+The containers need to be run as `root` due to `subuid` and `subgui` limits.
+
+```nohl
+sh# whoami
+root
+```
+
+## Preparing the environment
+
+Create the configuration:
+
+```
+python3 -m venv /tmp/ipalab
+. /tmp/ipalab/bin/activate
+pip install -r requirements.txt
+```
+
+Build the containers:
+
+```
+ipalab-config -f containerfile-fedora ipalab-idmtoidm-trust.yaml
+podman-compose -f idm2idm-trust/compose.yml up -d --build
+ansible-galaxy collection install -r idm2idm-trust/requirements.yml
+```
+
+Deploy the IPA cluster:
+
+```
+ansible-playbook -i idm2idm-trust/inventory.yml idm2idm-trust/playbooks/install-cluster.yml
+```
+
+Establish trust:
+
+```
+ansible-galaxy collection install ansible.posix
+ansible-playbook -i idm2idm-trust/inventory.yml establish-trust.yaml
+```

--- a/ipalab-config/containerfile-fedora
+++ b/ipalab-config/containerfile-fedora
@@ -1,0 +1,36 @@
+FROM registry.fedoraproject.org/fedora-toolbox:40
+MAINTAINER [FreeIPA Developers freeipa-devel@lists.fedorahosted.org]
+ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
+
+RUN echo 'deltarpm = false' >> /etc/dnf/dnf.conf \
+    && dnf copr enable -y abbra/wip-ipa-trust \
+    && dnf update -y dnf \
+    && dnf update -y python3 \
+    && (sed -i 's/%_install_langs \(.*\)/\0:fr/g' /etc/rpm/macros.image-language-conf ||:) \
+    && dnf install -y systemd \
+    && dnf install -y \
+        firewalld \
+        git \
+        glibc-langpack-fr \
+        glibc-langpack-en \
+        iptables \
+        nss-tools \
+        openssh-server \
+        sudo \
+        wget \
+        freeipa-server-trust-ad \
+        freeipa-server-dns \
+    && dnf clean all \
+    && sed -i 's/.*PermitRootLogin .*/#&/g' /etc/ssh/sshd_config \
+    && echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config \
+    && sed -i -e 's@^\(session.*required.*pam_loginuid\)@#\1@' /etc/pam.d/sshd \
+    && systemctl enable sshd \
+    && for i in /usr/lib/systemd/system/*-domainname.service; \
+    do sed -i 's#^ExecStart=/#ExecStart=-/#' $i ; done \
+    && { systemctl mask firewalld ||: ; } \
+    && { systemctl mask systemd-resolved ||: ; } \
+    && systemctl set-default multi-user.target
+
+STOPSIGNAL RTMIN+3
+VOLUME ["/freeipa", "/run", "/tmp"]
+ENTRYPOINT [ "/usr/sbin/init" ]

--- a/ipalab-config/establish-trust.yaml
+++ b/ipalab-config/establish-trust.yaml
@@ -1,0 +1,192 @@
+---
+- name: Estabilish IDM-to-IDM trust
+  hosts: ipaserver
+  become: false
+  gather_facts: false
+
+  vars:
+    m1_server: m1.ipa1demo.test
+    m2_server: m2.ipa2demo.test
+
+  tasks:
+  - name: Estabilish IDM-to-IDM trust
+    block:
+
+    - name: Ensure we have host DNS information
+      ansible.builtin.setup:
+        gather_subset: dns
+
+    - ansible.builtin.set_fact:
+        shortname: "{{ ansible_facts.fqdn.split('.')[0] }}"
+        domain_name: "{{ ansible_facts.fqdn.split('.')[1:] | join('.') }}"
+        realm_name: "{{ ansible_facts.fqdn.split('.')[1:] | join('.') | upper }}"
+
+    - name: Set facts for trusted IDM
+      ansible.builtin.set_fact:
+        trusted_domain: "{{ m2_server.split('.')[1:] | join('.') }}"
+        trusted_realm: "{{ m2_server.split('.')[1:] | join('.') | upper }}"
+      when: ansible_facts.fqdn == m1_server
+
+    - name: Set facts for trusted IDM
+      ansible.builtin.set_fact:
+        trusted_domain: "{{ m1_server.split('.')[1:] | join('.') }}"
+        trusted_realm: "{{ m1_server.split('.')[1:] | join('.') | upper }}"
+      when: ansible_facts.fqdn == m2_server
+
+    - name: remove old trust information
+      ansible.builtin.shell: |
+        echo "{{ ipaadmin_password }}" | kinit admin
+        ipa trust-del "{{ domain_name }}"
+        ipa idrange-del "{{ realm_name }}_id_range"
+      register: remove_old_trust
+      failed_when: false
+      changed_when: not remove_old_trust.stderr
+
+    - name: collect domain information
+      shell: |
+        echo "{{ ipaadmin_password }}" | kinit admin
+        ipa idrange-show "{{ realm_name }}_id_range" --raw && \
+        ipa trustconfig-show --raw && \
+        (ipa dnsrecord-show "{{ domain_name }}" "{{ shortname }}" --raw | head -2)
+      register: domain_info_raw
+      changed_when: false
+
+    - name: Process domain information
+      ansible.builtin.set_fact:
+        domain_info: "{{ domain_info|d({})|combine({_key: _val}) }}"
+      loop: "{{ domain_info_raw.stdout_lines }}"
+      loop_control:
+        label: "Line {{ ndx }}"
+        index_var: ndx
+      vars:
+        _list: "{{ item.split(':')|map('trim') }}"
+        _key: "{{ _list.0}}"
+        _val: "{{ _list[1:]|select()|map('from_yaml')|combine }}"
+
+    - name: Run tasks with values from the other host of the trust on m1
+      delegate_to: m1.ipa1demo.test
+      delegate_facts: true
+      when: ansible_facts.fqdn == m2_server
+      block:
+        - name: Create DNS zone forwarder for ipa2demo.test
+          freeipa.ansible_freeipa.ipadnsforwardzone:
+            # We're delegating facts from the other side, so this is actually "trusted_domain"
+            name: "{{ domain_name }}"
+            forwarders:
+              - ip_address: "{{ domain_info.arecord }}"
+
+
+        # --- use freeipa -------------------------------------------
+        - name: Estabilish trust
+          # This requires a modified ansible-freeipa version,
+          # as 'ipa' is not supported in ipatrust
+          freeipa.ansible_freeipa.ipatrust:
+            realm: "{{ domain_info.cn }}"
+            admin: "admin@{{ domain_info.cn | upper }}"
+            password: "{{ hostvars[m2_server].ipaadmin_password }}"
+            two_way: true
+            range_type: ipa-ad-trust-posix
+            trust_type: "ipa"
+            state: present
+        # -----------------------------------------------------------
+
+        # - name: Establish trust
+        #   ansible.builtin.shell: |
+        #     echo "{{ hostvars[m1_server].ipaadmin_password }}" | kinit admin
+        #     echo "{{ hostvars[m2_server].ipaadmin_password }}" | \
+        #     ipa trust-add --type=ipa "{{ domain_info.cn }}" \
+        #                   --admin "admin@{{ domain_info.cn | upper }}" \
+        #                   --password --two-way=true \
+        #                   --range-type=ipa-ad-trust-posix
+
+        - name: clean up and SSSD
+          ansible.builtin.shell: |
+            sssctl cache-remove -ops
+            sssctl logs-remove -d
+
+    - name: Run tasks with values from the other host of the trust on m2
+      delegate_to: m2.ipa2demo.test
+      delegate_facts: true
+      when: ansible_facts.fqdn == m1_server
+      block:
+        - name: Create DNS zone forwarder for ipa1demo.test
+          freeipa.ansible_freeipa.ipadnsforwardzone:
+            # We're delegating facts from the other side, so this is actually "trusted_domain"
+            name: "{{ domain_name }}"
+            forwarders:
+              - ip_address: "{{ domain_info.arecord }}"
+
+        # --- use freeipa -------------------------------------------
+        - name: Estabilish trust
+          # This requires a modified ansible-freeipa version, as 'ipa' is not supported in ipatrust
+          freeipa.ansible_freeipa.ipatrust:
+            realm: "{{ domain_info.cn }}"
+            admin: "admin@{{ domain_info.cn | upper }}"
+            password: "{{ hostvars[m1_server].ipaadmin_password }}"
+            two_way: true
+            range_type: ipa-ad-trust-posix
+            trust_type: "ipa"
+            state: present
+        # -----------------------------------------------------------
+
+        # - name: Establish trust
+        #   ansible.builtin.shell: |
+        #     echo "{{ hostvars[m2_server].ipaadmin_password }}" | kinit admin
+        #     echo "{{ hostvars[m1_server].ipaadmin_password }}" | \
+        #     ipa trust-add --type=ipa "{{ domain_info.cn }}" \
+        #                   --admin "admin@{{ domain_info.cn | upper }}" \
+        #                   --password --two-way=true \
+        #                   --range-type=ipa-ad-trust-posix
+
+        - name: clean up and restart SSSD on IPA1DEMO side
+          ansible.builtin.shell: |
+            sssctl cache-remove -ops
+            sssctl logs-remove -d
+
+    - name: Restart SSSD
+      ansible.builtin.systemd_service:
+        name: sssd
+        state: restarted
+
+    - name: Give some time to SSSD to be fully reloaded
+      ansible.builtin.pause:
+        seconds: 30
+
+    - name: Get entries for trusted domain
+      ansible.builtin.shell: |
+        hostname -f
+        getent passwd "admin@{{ trusted_domain }}"
+        getent group "admins@{{ trusted_domain }}"
+      register: trust_test
+
+    - name: Result of IPA-to-IPA trust
+      debug:
+        var: trust_test.stdout_lines
+
+    rescue:
+      # In case of error, copy log files to localhost.
+      - name: Ensure we have a local directory
+        ansible.builtin.file:
+          state: directory
+          path: "logs_{{ '%Y%m%d-%H%M' | strftime }}/{{ item }}"
+          mode: 0755
+        loop:
+          - "{{ m1_server }}"
+          - "{{ m2_server }}"
+        run_once: true
+        delegate_to: localhost
+
+      - name: Copy logs
+        block:
+          - name: Copy Samba logs
+            ansible.posix.synchronize:
+              src: "{{ item }}"
+              dest: "logs_{{ '%Y%m%d-%H%M' | strftime }}/{{ ansible_facts.fqdn }}"
+              mode: pull
+            loop:
+              - /var/log/samba/
+              - /var/log/ipaserver-install.log
+              - /var/log/sssd/
+              - /var/log/httpd/
+              - /var/log/dirsrv/
+...

--- a/ipalab-config/ipalab-idmtoidm-trust.yaml
+++ b/ipalab-config/ipalab-idmtoidm-trust.yaml
@@ -1,0 +1,39 @@
+# Build configuration with
+#     $ ipalab-config -f containerfile-fedora ipalab-idmtoidm-trust.yaml
+---
+lab_name: idm2idm-trust
+container_fqdn: true
+containerfiles:
+  - containerfile-fedora
+ipa_deployments:
+  - name: t1
+    domain: ipa1demo.test
+    admin_password: Secret123
+    dm_password: Secret123
+    distro: containerfile-fedora
+    cluster:
+      servers:
+        - name: m1
+          capabilities:
+            - DNS
+            - AD
+          vars:
+            ipaserver_netbios_name: M1
+      clients:
+        - name: c1
+  - name: t2
+    domain: ipa2demo.test
+    admin_password: Secret123
+    dm_password: Secret123
+    distro: containerfile-fedora
+    cluster:
+      servers:
+        - name: m2
+          capabilities:
+            - DNS
+            - AD
+          vars:
+            ipaserver_netbios_name: M2
+      clients:
+        - name: c2
+...

--- a/ipalab-config/requirements.txt
+++ b/ipalab-config/requirements.txt
@@ -1,0 +1,2 @@
+ipalab-config>=0.4.1
+ansible-core


### PR DESCRIPTION
This patch adds instructions, configuration files, and playbooks to prepare an environment and create an IDM-to-IDM trust using Ansible.

The new 'establish-trust.yaml' provided tries to use Ansible collections to the greater extense possible, instead of 'ansible.bulitin.shell' and makes use of ansible-freeipa to all IPA commands currently supported.

Note that the use of ipalab-config is self-contained, not using any other file from the repository.