### PR TITLE
Use Github Action to run the idm-to-idm trust test

### DIFF
--- a/.github/workflows/github_action.yml
+++ b/.github/workflows/github_action.yml
@@ -1,0 +1,36 @@
+---
+name: test-with-action
+run-name: Test IPA-IPA trust using a Github Action
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    # branches:
+    #   - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-github-action:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Clone the repository
+        uses: actions/checkout@v4
+
+      - name: Build image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: containerfile-fedora
+          tags: latest
+          containerfiles: ipalab-config/containerfile-fedora
+
+      - name: Run tests using action
+        uses: rjeffman/FreeIPA-Cluster-Test@v1.1.0
+        with:
+          cluster_configuration: ipalab-config/ipalab-idmtoidm-trust.yaml
+          ansible_requirements: ipalab-config/playbooks/requirements.yml
+          test_playbooks: ipalab-config/playbooks/establish-trust.yaml

--- a/.github/workflows/test-ipa-ipa-trust.yml
+++ b/.github/workflows/test-ipa-ipa-trust.yml
@@ -54,23 +54,27 @@ jobs:
       - name: Generate containers
         run: |
           source venv/bin/activate
-          cd ipalab-config
-          ipalab-config -f containerfile-fedora -p playbooks ipalab-idmtoidm-trust.yaml
+          ipalab-config -f ipalab-config/containerfile-fedora \
+                        -p ipalab-config/playbooks \
+                        ipalab-config/ipalab-idmtoidm-trust.yaml
           podman-compose -f idm2idm-trust/compose.yml up -d
-          ansible-galaxy collection install -r idm2idm-trust/requirements.yml
+          ansible-galaxy collection install \
+                         -r idm2idm-trust/requirements.yml
 
       - name: Create IPA deployments
         run: |
           source venv/bin/activate
-          cd ipalab-config
           # disable 'become' on install-clupster.yml playbook
-          sed -i 's/become: .*$/become: false/' idm2idm-trust/playbooks/install-cluster.yml
-          ansible-playbook -i idm2idm-trust/inventory.yml idm2idm-trust/playbooks/install-cluster.yml
+          sed -i 's/become: .*$/become: false/' \
+              idm2idm-trust/playbooks/install-cluster.yml
+          ansible-playbook -i idm2idm-trust/inventory.yml \
+                           idm2idm-trust/playbooks/install-cluster.yml
 
       - name: Establish trust between IPA deployments
         run: |
           source venv/bin/activate
-          cd ipalab-config
           ansible-galaxy collection install ansible.posix
-          ansible-playbook -i idm2idm-trust/inventory.yml idm2idm-trust/playbooks/establish-trust.yaml -e on_github_workflow=true
+          ansible-playbook -i idm2idm-trust/inventory.yml \
+                           idm2idm-trust/playbooks/establish-trust.yaml \
+                           -e on_github_workflow=true
 ...

--- a/ipalab-config/playbooks/requirements.yml
+++ b/ipalab-config/playbooks/requirements.yml
@@ -1,0 +1,4 @@
+---
+collections:
+  - name: ansible.posix
+...


### PR DESCRIPTION
This a first try on using a collection to test the cluster.

It is using https://github.com/rjeffman/FreeIPA-Cluster-Test as the action, which is "working but not ready".

Arguments, defaults and the execution process must be more well defined.

Current execution is able to run only a single Ansible playbook. It would be nice to run any number of playbooks (ansible-freeipa), or pytest with multihost support (FreeIPA or ansible-freeipa downstream).

It also uses a hard-coded "CONFIGDIR" directory that need to be modified, e.g. "CONFIGDIR-${{ gihtub.run-id }}", or some other unique parameter per run (sorry, I don't know the names, and didn't search at this time).

Another change that the action should offer (e.g. for being usable by ansible-freeipa), is to allow setting the "working directory". In the case of freeipal-local-tests, this could be "./ipalab-config".

Note that I disable the filter to run the tests onlo the main branch, so it is easier to run on a forked branch, on the contributor's fork. We can re-enable the filter before merging.