### PR TITLE
Use 'nolog: true' for Github actions

### DIFF
--- a/ipalab-config/ipa-migrate/ipalab-migration.yaml
+++ b/ipalab-config/ipa-migrate/ipalab-migration.yaml
@@ -16,6 +16,7 @@ ipa_deployments:
     cluster:
       servers:
         - name: m1
+          nolog: true
           capabilities:
             - DNS
             - AD
@@ -35,6 +36,7 @@ ipa_deployments:
     cluster:
       servers:
         - name: m2
+          nolog: true
           capabilities:
             - DNS
             - AD

--- a/ipalab-config/ipa-trust/ipalab-idmtoidm-trust.yaml
+++ b/ipalab-config/ipa-trust/ipalab-idmtoidm-trust.yaml
@@ -16,6 +16,7 @@ ipa_deployments:
     cluster:
       servers:
         - name: m1
+          nolog: true
           capabilities:
             - DNS
             - AD
@@ -37,6 +38,7 @@ ipa_deployments:
     cluster:
       servers:
         - name: m2
+          nolog: true
           capabilities:
             - DNS
             - AD

--- a/ipalab-config/localkdc/ipalab-localkdc.yaml
+++ b/ipalab-config/localkdc/ipalab-localkdc.yaml
@@ -13,8 +13,10 @@ ipa_deployments:
   - name: localkdcs
     domain: localkdc.test
     cluster:
-      clients: 
+      clients:
         - name: ab
+          nolog: true
           distro: fedora-localkdc
         - name: asn
+          nolog: true
           distro: fedora-localkdc


### PR DESCRIPTION
ipalab-config, by default mounts /var/log on the host to allow log evaluation after execution. This is working on local machines and on Azure, but seems to be failing on Github actions.

A workaround until a better solution is found is to use 'nolog: true' on each configured node.