### PR TITLE
localkdc: update to use Fedora 42 and IAKerb discovery

### DIFF
--- a/.github/workflows/github_action.yml
+++ b/.github/workflows/github_action.yml
@@ -26,7 +26,7 @@ jobs:
           containerfiles: ipalab-config/ipa-trust/containerfile-fedora
 
       - name: Run tests using action
-        uses: rjeffman/FreeIPA-Cluster-Test@v1.3.0
+        uses: rjeffman/FreeIPA-Cluster-Test
         with:
           cluster_configuration: ipalab-config/ipa-trust/ipalab-idmtoidm-trust.yaml
           ansible_requirements: ipalab-config/ipa-trust/playbooks/requirements.yml

--- a/.github/workflows/test-ipa-ipa-trust.yml
+++ b/.github/workflows/test-ipa-ipa-trust.yml
@@ -69,9 +69,9 @@ jobs:
           cd ./idm2idm-trust
           # disable 'become' on install-clupster.yml playbook
           sed -i 's/become: .*$/become: false/' \
-              playbooks/install-cluster.yml
+              ${HOME}/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml
           ansible-playbook -i inventory.yml \
-                           playbooks/install-cluster.yml
+                           ${HOME}/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml
 
       - name: Establish trust between IPA deployments
         run: |

--- a/.github/workflows/test-ipa-migrate.yml
+++ b/.github/workflows/test-ipa-migrate.yml
@@ -69,10 +69,10 @@ jobs:
           cd ./ipalab-migration
           # disable 'become' on install-clupster.yml playbook
           sed -i 's/become: .*$/become: false/' \
-              playbooks/install-cluster.yml
+              ${HOME}/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml
           ansible-playbook -i inventory.yml \
-                           playbooks/install-cluster.yml
-          ansible-playbook -i inventory.yml playbooks/install-cluster.yml
+                           ${HOME}/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml
+          ansible-playbook -i inventory.yml ${HOME}/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml
 
       - name: Generate Identity Management Data on the Origin Server
         run: |

--- a/ipalab-config/ipa-migrate/README.md
+++ b/ipalab-config/ipa-migrate/README.md
@@ -24,7 +24,7 @@ ansible-galaxy collection install -r requirements.yml
 Deploy the IPA cluster:
 
 ```
-ansible-playbook -i inventory.yml playbooks/install-cluster.yml
+ansible-playbook -i inventory.yml ${HOME}/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml
 ```
 
 ## Create some objects in the origin server

--- a/ipalab-config/ipa-trust/README.md
+++ b/ipalab-config/ipa-trust/README.md
@@ -22,7 +22,7 @@ ansible-galaxy collection install -r requirements.yml
 Deploy the IPA cluster:
 
 ```
-ansible-playbook -i inventory.yml playbooks/install-cluster.yml
+ansible-playbook -i inventory.yml ${HOME}/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml
 ```
 
 Establish trust:

--- a/ipalab-config/localkdc/Containerfile.localkdc
+++ b/ipalab-config/localkdc/Containerfile.localkdc
@@ -1,4 +1,4 @@
-FROM registry.fedoraproject.org/fedora-toolbox:41
+FROM registry.fedoraproject.org/fedora-toolbox:42
 MAINTAINER [FreeIPA Developers freeipa-devel@lists.fedorahosted.org]
 ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 

--- a/ipalab-config/localkdc/playbooks/tapes/localkdc-demo.tape
+++ b/ipalab-config/localkdc/playbooks/tapes/localkdc-demo.tape
@@ -102,8 +102,10 @@ Type "# Access a home SMB share on a different machine with Kerberos IAKerb exte
 Enter
 Type "# This time we would type a password but Samba will not use NTLM protocol"
 Enter
+Type "# Notice also we do not specify any Kerberos realm"
+Enter
 Sleep 2s
-Type "smbclient -U testuser@ASN.LOCALKDC.SITE --client-protection=encrypt //asn.localkdc.test/homes"
+Type "smbclient -U testuser --client-protection=encrypt //asn.localkdc.test/homes"
 Enter
 Sleep 1s
 Type "Secret123"

--- a/ipalab-config/minimal/README.md
+++ b/ipalab-config/minimal/README.md
@@ -54,7 +54,7 @@ ansible-freeipa playbooks. These playbooks installed by `ipalab-config`
 automatically:
 
 ```
-ansible-playbook -i inventory.yml playbooks/install-cluster.yml
+ansible-playbook -i inventory.yml ${HOME}/.ansible/collections/ansible_collections/freeipa/ansible_freeipa/playbooks/install-cluster.yml
 ```
 
 After successful run of the playbook two FreeIPA systems would be provisioned:


### PR DESCRIPTION
COPR repository asn/localkdc was updated with recent krb5 and samba builds. Due to changes in ABI for Samba 4.22 only F42 builds are usable.

krb5 build supports IAKerb discovery, adjust the demo recording to use that.